### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PySOFT
 
 [![Build Status](https://travis-ci.org/kpj/PySOFT.png)](https://travis-ci.org/kpj/PySOFT)
-[![Latest Version](https://pypip.in/version/pysoft/badge.svg)](https://pypi.python.org/pypi/pysoft/)
-[![Downloads](https://pypip.in/download/PySOFT/badge.svg)](https://pypi.python.org/pypi/PySOFT/)
+[![Latest Version](https://img.shields.io/pypi/v/pysoft.svg)](https://pypi.python.org/pypi/pysoft/)
+[![Downloads](https://img.shields.io/pypi/dm/PySOFT.svg)](https://pypi.python.org/pypi/PySOFT/)
 
 
 Parser for the SOFT (Simple Omnibus Format in Text) file format.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pysoft))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pysoft`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.